### PR TITLE
Add CI test generating shelf SVG

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 ---
-name: Build shelf SVG
+name: CI build
 
 'on':
   push:
@@ -8,7 +8,7 @@ name: Build shelf SVG
     branches: [main]
 
 jobs:
-  generate:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -39,20 +39,30 @@ jobs:
           cabal update
           cabal build
 
+      - name: Find executable
+        id: list-bin
+        run: echo "path=$(cabal list-bin shelf-generator)" >> "$GITHUB_OUTPUT"
+
       - name: Run generator
-        run: >-
-          cabal run shelf-generator --
-          --thickness 3
-          --rows 5
-          --cols 4
-          --cell-width 100
-          --cell-height 100
-          --area-width 730
-          --area-height 410
-          --output shelf.svg
+        run: |
+          "${{ steps.list-bin.outputs.path }}" \
+            --thickness 3 \
+            --rows 5 \
+            --cols 4 \
+            --cell-width 100 \
+            --cell-height 100 \
+            --area-width 730 \
+            --area-height 410 \
+            --output shelf.svg
 
       - name: Check SVG
         run: test -f shelf.svg
+
+      - name: Upload executable
+        uses: actions/upload-artifact@v4
+        with:
+          name: shelf-generator
+          path: ${{ steps.list-bin.outputs.path }}
 
       - name: Upload SVG artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/generate-shelf.yml
+++ b/.github/workflows/generate-shelf.yml
@@ -1,0 +1,36 @@
+name: Build shelf SVG
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Haskell
+        uses: actions/setup-haskell@v1
+        with:
+          ghc-version: '9.2'
+          cabal-version: '3.8'
+      - name: Build and run generator
+        run: |
+          cabal update
+          cabal build
+          cabal run shelf-generator -- \
+            --thickness 3 \
+            --rows 5 \
+            --cols 4 \
+            --cell-width 100 \
+            --cell-height 100 \
+            --area-width 730 \
+            --area-height 410 \
+            --output shelf.svg
+      - name: Check SVG
+        run: test -f shelf.svg
+      - name: Upload SVG artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: shelf-svg
+          path: shelf.svg

--- a/.github/workflows/generate-shelf.yml
+++ b/.github/workflows/generate-shelf.yml
@@ -1,34 +1,59 @@
+---
 name: Build shelf SVG
 
-on:
+'on':
   push:
+    branches: [main]
   pull_request:
+    branches: [main]
 
 jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Haskell
-        uses: actions/setup-haskell@v1
+      - uses: actions/checkout@v4
+
+      - name: Setup Haskell
+        uses: haskell-actions/setup@v2
         with:
-          ghc-version: '9.2'
-          cabal-version: '3.8'
-      - name: Build and run generator
+          ghc-version: '9.6'
+          cabal-version: 'latest'
+
+      - name: Cache cabal packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+            dist-newstyle
+          key: >-
+            ${{ runner.os }}-cabal-${{ hashFiles(
+              '**/*.cabal',
+              'cabal.project*'
+            ) }}
+          restore-keys: |
+            ${{ runner.os }}-cabal-
+
+      - name: Build generator
         run: |
           cabal update
           cabal build
-          cabal run shelf-generator -- \
-            --thickness 3 \
-            --rows 5 \
-            --cols 4 \
-            --cell-width 100 \
-            --cell-height 100 \
-            --area-width 730 \
-            --area-height 410 \
-            --output shelf.svg
+
+      - name: Run generator
+        run: >-
+          cabal run shelf-generator --
+          --thickness 3
+          --rows 5
+          --cols 4
+          --cell-width 100
+          --cell-height 100
+          --area-width 730
+          --area-height 410
+          --output shelf.svg
+
       - name: Check SVG
         run: test -f shelf.svg
+
       - name: Upload SVG artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/generate-shelf.yml
+++ b/.github/workflows/generate-shelf.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check SVG
         run: test -f shelf.svg
       - name: Upload SVG artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: shelf-svg
           path: shelf.svg


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and run shelf generator with 5x4 grid and upload SVG artifact

## Testing
- `sudo apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(failed: The repository 'http://apt.llvm.org/noble llvm-toolchain-noble-20 InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aca7ea56808321a33f97f3f9edb402