### PR TITLE
Add generator test to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,50 @@ jobs:
       - uses: haskell-actions/setup@v2
         with:
           ghc-version: '9.6'
-          cabal-version: '3.10'
-      - name: Build
+          cabal-version: 'latest'
+
+      - name: Cache cabal packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+            dist-newstyle
+          key: ${{ runner.os }}-cabal-${{ hashFiles('**/*.cabal', 'cabal.project*') }}
+          restore-keys: ${{ runner.os }}-cabal-
+
+      - name: Build generator
         run: |
           cabal update
           cabal build
+
+      - name: Find executable
+        id: list-bin
+        run: echo "path=$(cabal list-bin shelf-generator)" >> "$GITHUB_OUTPUT"
+
+      - name: Run generator
+        run: |
+          "${{ steps.list-bin.outputs.path }}" \
+            --thickness 3 \
+            --rows 5 \
+            --cols 4 \
+            --cell-width 100 \
+            --cell-height 100 \
+            --area-width 730 \
+            --area-height 410 \
+            --output shelf.svg
+
+      - name: Check SVG
+        run: test -f shelf.svg
+
+      - name: Upload executable
+        uses: actions/upload-artifact@v4
+        with:
+          name: shelf-generator
+          path: ${{ steps.list-bin.outputs.path }}
+
+      - name: Upload SVG artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: shelf-svg
+          path: shelf.svg


### PR DESCRIPTION
## Summary
- build and cache cabal dependencies
- run shelf-generator to produce example SVG
- upload executable and generated SVG as build artifacts

## Testing
- `cabal build` *(fails: Could not resolve dependencies; optparse-applicative)*

------
https://chatgpt.com/codex/tasks/task_e_68b49f22bf8883218a68fe46ba56407b